### PR TITLE
feat: add reusable sanitizer knowledge store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,9 @@ ipython_config.py
 .pdm-build/
 
 # pixi
+
+# Runtime knowledge learned by MCP tools
+knowledge/
 #   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
 #pixi.lock
 #   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one

--- a/README.md
+++ b/README.md
@@ -3,3 +3,41 @@
 ```bash
 python src/demo_main.py
 ```
+
+## MCP Knowledge MVP
+
+The MCP server can now persist sanitizer experience learned from false-positive
+analysis and reuse it in later database scans.
+
+Current scope:
+
+- repo/global JSONL knowledge store under `knowledge/`
+- call-style sanitizer experience, for example `strip_parent_traversal(path)`
+- low-confidence-by-default records to avoid silently hiding true positives
+- MCP tools:
+  - `save_experience_pattern`
+  - `load_applicable_experiences`
+  - `update_experience_validation`
+
+Example experience:
+
+```json
+{
+  "scope": "repo",
+  "repo_id": "example/project",
+  "language": "cpp",
+  "cwe": "CWE-22",
+  "query_id": "path-injection",
+  "type": "call_sanitizer",
+  "function_name": "strip_parent_traversal",
+  "effect": "remove_parent_traversal_risk",
+  "confidence": "low",
+  "evidence": {
+    "file": "src/path.c",
+    "reason": "removes '..' from the path buffer"
+  }
+}
+```
+
+The first version only stores and retrieves experience. Query patch generation
+and stronger validation can be layered on top of these MCP tools later.

--- a/src/libs/lib_knowledge/__init__.py
+++ b/src/libs/lib_knowledge/__init__.py
@@ -1,0 +1,11 @@
+from .lib_knowledge import (
+    load_applicable_experiences,
+    save_experience_pattern,
+    update_experience_validation,
+)
+
+__all__ = [
+    "save_experience_pattern",
+    "load_applicable_experiences",
+    "update_experience_validation",
+]

--- a/src/libs/lib_knowledge/lib_knowledge.py
+++ b/src/libs/lib_knowledge/lib_knowledge.py
@@ -1,0 +1,326 @@
+import json
+import re
+import uuid
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_KNOWLEDGE_BASE = PROJECT_ROOT / "knowledge"
+
+ACTIVE_STATUSES = {"candidate", "active_low_confidence", "active", "active_high_confidence"}
+CONFIDENCE_ORDER = {
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+}
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _safe_repo_id(repo_id: Optional[str]) -> str:
+    if not repo_id:
+        return "unknown_repo"
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "_", repo_id.strip())
+    return safe.strip("._") or "unknown_repo"
+
+
+def _knowledge_base_path(knowledge_base_path: Optional[str] = None) -> Path:
+    return Path(knowledge_base_path).expanduser() if knowledge_base_path else DEFAULT_KNOWLEDGE_BASE
+
+
+def _experience_file(scope: str, repo_id: Optional[str], knowledge_base_path: Optional[str] = None) -> Path:
+    base = _knowledge_base_path(knowledge_base_path)
+    if scope == "global":
+        return base / "global" / "experiences.jsonl"
+    return base / "repos" / _safe_repo_id(repo_id) / "experiences.jsonl"
+
+
+def _normalize_cwe(cwe: Optional[str]) -> Optional[str]:
+    if cwe is None:
+        return None
+    raw = str(cwe).strip()
+    if not raw:
+        return None
+    if raw.upper().startswith("CWE-"):
+        return raw.upper()
+    if raw.isdigit():
+        return f"CWE-{raw}"
+    return raw
+
+
+def _normalize_confidence(confidence: Optional[str]) -> str:
+    if not confidence:
+        return "low"
+    normalized = str(confidence).strip().lower()
+    return normalized if normalized in CONFIDENCE_ORDER else "low"
+
+
+def _normalize_scope(scope: Optional[str]) -> str:
+    normalized = (scope or "repo").strip().lower()
+    return "global" if normalized == "global" else "repo"
+
+
+def _read_jsonl(path: Path) -> List[Dict[str, Any]]:
+    if not path.exists():
+        return []
+
+    records: List[Dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line_no, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"Invalid JSON in {path}:{line_no}: {exc}") from exc
+            if isinstance(value, dict):
+                records.append(value)
+    return records
+
+
+def _write_jsonl(path: Path, records: Iterable[Dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    with tmp_path.open("w", encoding="utf-8") as f:
+        for record in records:
+            f.write(json.dumps(record, ensure_ascii=False, sort_keys=True))
+            f.write("\n")
+    tmp_path.replace(path)
+
+
+def _append_jsonl(path: Path, record: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(record, ensure_ascii=False, sort_keys=True))
+        f.write("\n")
+
+
+def _required_string(value: Any, field_name: str) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return text
+
+
+def _normalize_experience(pattern: Dict[str, Any]) -> Dict[str, Any]:
+    if not isinstance(pattern, dict):
+        raise ValueError("pattern must be a JSON object")
+
+    experience = deepcopy(pattern)
+    scope = _normalize_scope(experience.get("scope"))
+    repo_id = _required_string(experience.get("repo_id"), "repo_id")
+    if scope == "repo" and not repo_id:
+        raise ValueError("repo_id is required for repo scoped experience")
+
+    exp_type = _required_string(experience.get("type"), "type") or "call_sanitizer"
+    function_name = _required_string(experience.get("function_name"), "function_name")
+    matcher = experience.get("matcher")
+    if not function_name and isinstance(matcher, dict):
+        function_name = _required_string(matcher.get("function_name"), "matcher.function_name")
+    if exp_type == "call_sanitizer" and not function_name:
+        raise ValueError("function_name is required for call_sanitizer experience")
+
+    now = _utc_now()
+    experience["id"] = _required_string(experience.get("id"), "id") or f"exp-{uuid.uuid4().hex}"
+    experience["version"] = int(experience.get("version", 1))
+    experience["scope"] = scope
+    if repo_id:
+        experience["repo_id"] = repo_id
+    experience["language"] = _required_string(experience.get("language"), "language")
+    experience["cwe"] = _normalize_cwe(experience.get("cwe"))
+    experience["query_id"] = _required_string(experience.get("query_id"), "query_id")
+    experience["type"] = exp_type
+    if function_name:
+        experience["function_name"] = function_name
+    experience["confidence"] = _normalize_confidence(experience.get("confidence"))
+    experience["status"] = _required_string(experience.get("status"), "status") or "candidate"
+    experience["created_at"] = _required_string(experience.get("created_at"), "created_at") or now
+    experience["updated_at"] = now
+
+    evidence = experience.get("evidence")
+    experience["evidence"] = evidence if isinstance(evidence, dict) else {}
+
+    validation = experience.get("validation")
+    if not isinstance(validation, dict):
+        validation = {}
+    validation.setdefault("validated_count", 0)
+    validation.setdefault("rejected_count", 0)
+    validation.setdefault("notes", [])
+    experience["validation"] = validation
+
+    return experience
+
+
+def _matches_optional(record_value: Any, query_value: Optional[str], normalize_cwe: bool = False) -> bool:
+    if query_value is None:
+        return True
+    if record_value in (None, ""):
+        return True
+    left = _normalize_cwe(record_value) if normalize_cwe else str(record_value).strip().lower()
+    right = _normalize_cwe(query_value) if normalize_cwe else str(query_value).strip().lower()
+    return left == right
+
+
+def _load_candidate_files(
+    repo_id: Optional[str],
+    include_global: bool,
+    knowledge_base_path: Optional[str],
+) -> List[Path]:
+    files = []
+    if repo_id:
+        files.append(_experience_file("repo", repo_id, knowledge_base_path))
+    if include_global:
+        files.append(_experience_file("global", None, knowledge_base_path))
+    return files
+
+
+def save_experience_pattern(pattern: Dict[str, Any], knowledge_base_path: Optional[str] = None) -> Dict[str, Any]:
+    """Save one LLM learned experience pattern into the JSONL knowledge store."""
+    try:
+        experience = _normalize_experience(pattern)
+        path = _experience_file(experience["scope"], experience.get("repo_id"), knowledge_base_path)
+        existing = _read_jsonl(path)
+        if any(item.get("id") == experience["id"] for item in existing):
+            return {
+                "success": False,
+                "error": f"experience id already exists: {experience['id']}",
+                "experience_id": experience["id"],
+                "knowledge_file": str(path),
+            }
+
+        _append_jsonl(path, experience)
+        return {
+            "success": True,
+            "experience_id": experience["id"],
+            "experience": experience,
+            "knowledge_file": str(path),
+            "message": "experience pattern saved",
+        }
+    except Exception as exc:
+        return {"success": False, "error": str(exc)}
+
+
+def load_applicable_experiences(
+    repo_id: Optional[str] = None,
+    language: Optional[str] = None,
+    cwe: Optional[str] = None,
+    query_id: Optional[str] = None,
+    experience_type: Optional[str] = None,
+    function_name: Optional[str] = None,
+    min_confidence: str = "low",
+    include_global: bool = True,
+    include_rejected: bool = False,
+    knowledge_base_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Load repo/global experiences that may apply to the current database analysis."""
+    try:
+        min_rank = CONFIDENCE_ORDER.get(_normalize_confidence(min_confidence), 1)
+        files = _load_candidate_files(repo_id, include_global, knowledge_base_path)
+        experiences: List[Dict[str, Any]] = []
+
+        for path in files:
+            for record in _read_jsonl(path):
+                status = str(record.get("status", "")).strip()
+                if not include_rejected and status not in ACTIVE_STATUSES:
+                    continue
+                if CONFIDENCE_ORDER.get(_normalize_confidence(record.get("confidence")), 1) < min_rank:
+                    continue
+                if not _matches_optional(record.get("language"), language):
+                    continue
+                if not _matches_optional(record.get("cwe"), cwe, normalize_cwe=True):
+                    continue
+                if not _matches_optional(record.get("query_id"), query_id):
+                    continue
+                if not _matches_optional(record.get("type"), experience_type):
+                    continue
+                if function_name and str(record.get("function_name", "")).strip() != function_name:
+                    continue
+                record_copy = deepcopy(record)
+                record_copy["_knowledge_file"] = str(path)
+                experiences.append(record_copy)
+
+        return {
+            "success": True,
+            "experiences": experiences,
+            "count": len(experiences),
+            "knowledge_files": [str(path) for path in files],
+        }
+    except Exception as exc:
+        return {"success": False, "error": str(exc)}
+
+
+def update_experience_validation(
+    experience_id: str,
+    repo_id: Optional[str] = None,
+    scope: str = "repo",
+    status: Optional[str] = None,
+    confidence: Optional[str] = None,
+    validation_result: Optional[str] = None,
+    note: Optional[str] = None,
+    knowledge_base_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Update validation metadata for a saved experience."""
+    try:
+        if not experience_id:
+            raise ValueError("experience_id is required")
+
+        normalized_scope = _normalize_scope(scope)
+        path = _experience_file(normalized_scope, repo_id, knowledge_base_path)
+        records = _read_jsonl(path)
+        updated_record: Optional[Dict[str, Any]] = None
+
+        for record in records:
+            if record.get("id") != experience_id:
+                continue
+
+            if status:
+                record["status"] = str(status).strip()
+            if confidence:
+                record["confidence"] = _normalize_confidence(confidence)
+
+            validation = record.get("validation")
+            if not isinstance(validation, dict):
+                validation = {}
+            validation.setdefault("validated_count", 0)
+            validation.setdefault("rejected_count", 0)
+            validation.setdefault("notes", [])
+
+            normalized_result = str(validation_result or "").strip().lower()
+            if normalized_result in {"pass", "passed", "valid", "validated", "accepted"}:
+                validation["validated_count"] = int(validation.get("validated_count", 0)) + 1
+            elif normalized_result in {"fail", "failed", "invalid", "rejected"}:
+                validation["rejected_count"] = int(validation.get("rejected_count", 0)) + 1
+
+            if note:
+                validation["notes"].append({"time": _utc_now(), "text": str(note)})
+
+            record["validation"] = validation
+            record["updated_at"] = _utc_now()
+            updated_record = record
+            break
+
+        if updated_record is None:
+            return {
+                "success": False,
+                "error": f"experience not found: {experience_id}",
+                "knowledge_file": str(path),
+            }
+
+        _write_jsonl(path, records)
+        return {
+            "success": True,
+            "experience_id": experience_id,
+            "experience": updated_record,
+            "knowledge_file": str(path),
+            "message": "experience validation updated",
+        }
+    except Exception as exc:
+        return {"success": False, "error": str(exc)}

--- a/src/libs/lib_sanitizer/readme.md
+++ b/src/libs/lib_sanitizer/readme.md
@@ -38,8 +38,37 @@
     *   **输入**: `patched_ql_path`  和 `new_content` (包含新 Sanitizer 定义的完整或片段 QL 代码)。
     *   **目的**: 将新的 Sanitizer 逻辑写入查询脚本，消除误报。
 
+## Step 5: 保存可复用经验
+如果 Step 4 中确认某个项目内部函数或模式具有 Sanitizer 效果，请使用工具 `save_experience_pattern` 将其保存为结构化经验，供后续 database 分析复用。
+*   **输入**: 一个 JSON 对象，至少包含：
+    ```json
+    {
+      "scope": "repo",
+      "repo_id": "...",
+      "language": "cpp",
+      "cwe": "CWE-...",
+      "query_id": "...",
+      "type": "call_sanitizer",
+      "function_name": "...",
+      "effect": "...",
+      "confidence": "low",
+      "evidence": {
+        "database": "...",
+        "file": "...",
+        "reason": "..."
+      }
+    }
+    ```
+*   **注意**: 新经验默认应使用 `confidence: "low"`，不要因为一次 LLM 判断就直接高置信度 suppress 后续告警。
+
+## Step 6: 复用历史经验
+在分析新的 database 或同一 repo 的后续版本前，可以先使用 `load_applicable_experiences` 根据 `repo_id`、`language`、`cwe`、`query_id` 等条件读取历史经验。
+*   如果历史经验适用，可以用它辅助生成当前 database 的 QL patch。
+*   如果人工或回归测试确认经验有效，可以使用 `update_experience_validation` 更新状态、置信度和验证次数。
+
 # Constraints
 *   在调用工具前，请简要说明你的分析思路。
 *   如果 `read_function_implementation` 返回空（找不到文件），请尝试根据函数名推断其用途。
 *   生成的 QL 代码必须语法正确且符合 CodeQL 标准库规范。
+*   低置信度经验只能作为辅助判断或待复核标记，不应直接导致真实告警被静默删除。
 ```

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,15 @@
+from typing import Optional
+
 from fastmcp import FastMCP
 from libs.lib_sanitizer import (
     patch_ql,
     read_function_implementation,
     run_taint_analysis,
+)
+from libs.lib_knowledge import (
+    load_applicable_experiences,
+    save_experience_pattern,
+    update_experience_validation,
 )
 
 # 初始化 MCP Server
@@ -37,6 +44,73 @@ def read_function_implementation_tool(function_name: str, file_path: str) -> dic
 def patch_ql_tool(patched_ql_path: str, new_content: str) -> dict:
     """将新内容写入指定的 QL 文件"""
     return patch_ql(patched_ql_path, new_content)
+
+
+@mcp.tool(
+    name="save_experience_pattern",
+    description="保存 LLM 从误报分析中总结出的 repo/global 级 sanitizer 经验"
+)
+def save_experience_pattern_tool(pattern: dict, knowledge_base_path: Optional[str] = None) -> dict:
+    """保存结构化经验，默认写入项目 knowledge 目录"""
+    return save_experience_pattern(pattern, knowledge_base_path)
+
+
+@mcp.tool(
+    name="load_applicable_experiences",
+    description="根据 repo、语言、CWE/query 等条件读取可复用的经验"
+)
+def load_applicable_experiences_tool(
+    repo_id: Optional[str] = None,
+    language: Optional[str] = None,
+    cwe: Optional[str] = None,
+    query_id: Optional[str] = None,
+    experience_type: Optional[str] = None,
+    function_name: Optional[str] = None,
+    min_confidence: str = "low",
+    include_global: bool = True,
+    include_rejected: bool = False,
+    knowledge_base_path: Optional[str] = None,
+) -> dict:
+    """读取适用于当前 database 分析的经验列表"""
+    return load_applicable_experiences(
+        repo_id=repo_id,
+        language=language,
+        cwe=cwe,
+        query_id=query_id,
+        experience_type=experience_type,
+        function_name=function_name,
+        min_confidence=min_confidence,
+        include_global=include_global,
+        include_rejected=include_rejected,
+        knowledge_base_path=knowledge_base_path,
+    )
+
+
+@mcp.tool(
+    name="update_experience_validation",
+    description="更新经验的置信度、状态和验证计数"
+)
+def update_experience_validation_tool(
+    experience_id: str,
+    repo_id: Optional[str] = None,
+    scope: str = "repo",
+    status: Optional[str] = None,
+    confidence: Optional[str] = None,
+    validation_result: Optional[str] = None,
+    note: Optional[str] = None,
+    knowledge_base_path: Optional[str] = None,
+) -> dict:
+    """在人工或回归验证后更新经验状态"""
+    return update_experience_validation(
+        experience_id=experience_id,
+        repo_id=repo_id,
+        scope=scope,
+        status=status,
+        confidence=confidence,
+        validation_result=validation_result,
+        note=note,
+        knowledge_base_path=knowledge_base_path,
+    )
 
 if __name__ == "__main__":
     # 以 Streamable HTTP 模式运行，端口 8000

--- a/test/test_lib_knowledge.py
+++ b/test/test_lib_knowledge.py
@@ -1,0 +1,73 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import sys
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = PROJECT_ROOT / "src"
+sys.path.insert(0, str(SRC_ROOT))
+
+from libs.lib_knowledge import (  # noqa: E402
+    load_applicable_experiences,
+    save_experience_pattern,
+    update_experience_validation,
+)
+
+
+class KnowledgeStoreTest(unittest.TestCase):
+    def test_save_load_and_update_repo_experience(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            saved = save_experience_pattern(
+                {
+                    "scope": "repo",
+                    "repo_id": "example/project",
+                    "language": "cpp",
+                    "cwe": "22",
+                    "query_id": "path-injection",
+                    "type": "call_sanitizer",
+                    "function_name": "strip_parent_traversal",
+                    "effect": "remove_parent_traversal_risk",
+                    "evidence": {
+                        "file": "src/path.c",
+                        "reason": "removes '..' from the path buffer",
+                    },
+                },
+                knowledge_base_path=tmp_dir,
+            )
+
+            self.assertTrue(saved["success"])
+            self.assertEqual(saved["experience"]["confidence"], "low")
+            self.assertEqual(saved["experience"]["status"], "candidate")
+
+            loaded = load_applicable_experiences(
+                repo_id="example/project",
+                language="cpp",
+                cwe="CWE-22",
+                query_id="path-injection",
+                experience_type="call_sanitizer",
+                knowledge_base_path=tmp_dir,
+            )
+
+            self.assertTrue(loaded["success"])
+            self.assertEqual(loaded["count"], 1)
+            self.assertEqual(loaded["experiences"][0]["function_name"], "strip_parent_traversal")
+
+            updated = update_experience_validation(
+                experience_id=saved["experience_id"],
+                repo_id="example/project",
+                status="active_low_confidence",
+                validation_result="passed",
+                note="confirmed on current false positive case",
+                knowledge_base_path=tmp_dir,
+            )
+
+            self.assertTrue(updated["success"])
+            self.assertEqual(updated["experience"]["status"], "active_low_confidence")
+            self.assertEqual(updated["experience"]["validation"]["validated_count"], 1)
+            self.assertEqual(len(updated["experience"]["validation"]["notes"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# PR Summary

## What Changed
- Add a JSONL-backed knowledge store for sanitizer experience learned during false-positive analysis.
- Expose MCP tools to save applicable experience, load repo/global experience, and update validation metadata.
- Document the knowledge MVP workflow and sanitizer experience reuse guidance.
- Add unit coverage for saving, loading, and validating repo-scoped experience.

## Scope and Impact
- Affected modules/files: `src/libs/lib_knowledge`, `src/main.py`, `src/libs/lib_sanitizer/readme.md`, `README.md`, `.gitignore`, `test/test_lib_knowledge.py`
- User-facing impact: MCP users can persist low-confidence sanitizer patterns and reuse them in later database scans.
- Potential risks or compatibility concerns: Runtime knowledge is stored under ignored `knowledge/` paths; saved experiences default to low confidence and should be validated before any stronger suppression behavior is added.

## Validation
- [x] Local verification completed
- [x] Existing tests pass
- [x] New tests added or updated if needed

Validation details:
- Commands run:
  - `python3 test/test_lib_knowledge.py`
  - `python3 -m unittest discover test`
- Key results: both commands passed.

## Related Issues
- Closes #12
- Related to #10

## Checklist
- [x] I reviewed the changed code
- [x] I removed unrelated changes
- [x] I updated documentation if needed
- [x] I considered backward compatibility and regression risk
