### PR TITLE
feat: add bidirectional QL swap script and auto-maintain patching map…

### DIFF
--- a/scripts/swap_ql.py
+++ b/scripts/swap_ql.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+双向 QL 文件替换脚本。
+
+输入：一个 JSON 文件，记录 original_ql -> patched_ql 的映射关系。
+
+JSON 格式示例：
+{
+    "mappings": [
+        {
+            "original_ql": "/abs/path/to/original.ql",
+            "patched_ql": "/abs/path/to/scripts/.CODEQL-AI/patched-ql/patched.ql"
+        }
+    ]
+}
+
+操作模式：
+  apply   — 备份 original_ql 到 old-ql/，用 patched_ql 覆盖 original_ql
+  restore — 将 old-ql/ 中的备份写回 original_ql
+"""
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+CODEQL_AI_DIR = SCRIPT_DIR / ".CODEQL-AI"
+OLD_QL_DIR = CODEQL_AI_DIR / "old-ql"
+PATCHED_QL_DIR = CODEQL_AI_DIR / "patched-ql"
+
+
+def backup_key(original_ql: str) -> str:
+    """将绝对路径转成扁平的备份文件名，避免冲突。"""
+    return original_ql.strip("/").replace("/", "__")
+
+
+def ensure_dirs():
+    OLD_QL_DIR.mkdir(parents=True, exist_ok=True)
+    PATCHED_QL_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def load_mappings(json_path: str) -> list:
+    with open(json_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    mappings = data.get("mappings", [])
+    if not mappings:
+        print("错误：JSON 中没有 mappings 或为空", file=sys.stderr)
+        sys.exit(1)
+    return mappings
+
+
+def apply_patches(mappings: list, force: bool = False):
+    """备份原始 QL，用 patched QL 覆盖。"""
+    ensure_dirs()
+    for entry in mappings:
+        original = Path(entry["original_ql"])
+        patched = Path(entry["patched_ql"])
+
+        if not original.exists():
+            print(f"跳过：原始文件不存在 {original}")
+            continue
+        if not patched.exists():
+            print(f"跳过：patched 文件不存在 {patched}")
+            continue
+
+        backup_path = OLD_QL_DIR / backup_key(str(original))
+
+        if backup_path.exists() and not force:
+            print(f"备份已存在，跳过备份（使用 --force 覆盖）：{backup_path.name}")
+        else:
+            shutil.copy2(str(original), str(backup_path))
+            print(f"已备份：{original} -> {backup_path.name}")
+
+        shutil.copy2(str(patched), str(original))
+        print(f"已应用：{patched} -> {original}")
+
+
+def restore_originals(mappings: list):
+    """将备份还原到原始位置。"""
+    for entry in mappings:
+        original = Path(entry["original_ql"])
+        backup_path = OLD_QL_DIR / backup_key(str(original))
+
+        if not backup_path.exists():
+            print(f"跳过：备份不存在 {backup_path.name}")
+            continue
+
+        shutil.copy2(str(backup_path), str(original))
+        print(f"已还原：{backup_path.name} -> {original}")
+
+
+def show_status(mappings: list):
+    """显示当前映射的状态。"""
+    for entry in mappings:
+        original = Path(entry["original_ql"])
+        patched = Path(entry["patched_ql"])
+        backup_path = OLD_QL_DIR / backup_key(str(original))
+
+        status_parts = []
+        if backup_path.exists():
+            status_parts.append("有备份")
+        else:
+            status_parts.append("无备份")
+        if not original.exists():
+            status_parts.append("原始文件缺失")
+        if not patched.exists():
+            status_parts.append("patched文件缺失")
+
+        status = ", ".join(status_parts)
+        print(f"  [{status}] {original.name}")
+        print(f"    原始: {original}")
+        print(f"    补丁: {patched}")
+        print()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="双向 QL 文件替换工具")
+    parser.add_argument("action", choices=["apply", "restore", "status"],
+                        help="apply=用patched覆盖原始, restore=还原备份, status=查看状态")
+    parser.add_argument("json_file", help="映射关系 JSON 文件路径")
+    parser.add_argument("--force", action="store_true",
+                        help="apply 时强制覆盖已有备份")
+
+    args = parser.parse_args()
+    mappings = load_mappings(args.json_file)
+
+    if args.action == "apply":
+        apply_patches(mappings, force=args.force)
+    elif args.action == "restore":
+        restore_originals(mappings)
+    elif args.action == "status":
+        show_status(mappings)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/libs/lib_sanitizer/__init__.py
+++ b/src/libs/lib_sanitizer/__init__.py
@@ -1,3 +1,3 @@
-from .lib_sanitizer import patch_ql, read_function_implementation, run_taint_analysis
+from .lib_sanitizer import patch_ql, read_function_implementation, run_taint_analysis, PATCHED_QL_DIR, QL_MAPPINGS_PATH
 
-__all__ = ["run_taint_analysis", "read_function_implementation", "patch_ql"]
+__all__ = ["run_taint_analysis", "read_function_implementation", "patch_ql", "PATCHED_QL_DIR", "QL_MAPPINGS_PATH"]

--- a/src/libs/lib_sanitizer/lib_sanitizer.py
+++ b/src/libs/lib_sanitizer/lib_sanitizer.py
@@ -1,6 +1,7 @@
 import asyncio
+import json
 import re
-from typing import List
+from typing import List, Optional
 import shlex
 from pathlib import Path
 
@@ -233,32 +234,66 @@ def read_function_implementation(function_name: str, file_path: str) -> dict:
     
     return {"success": True, "error": f"可能为lib库标准函数: {function_name}"}
 
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+PATCHED_QL_DIR = PROJECT_ROOT / "scripts" / ".CODEQL-AI" / "patched-ql"
+QL_MAPPINGS_PATH = PROJECT_ROOT / "scripts" / ".CODEQL-AI" / "ql_mappings.json"
+
+
+def _update_ql_mappings(original_ql: str, patched_ql: str) -> None:
+    """更新 ql_mappings.json，同一 original_ql 不重复添加。"""
+    QL_MAPPINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+    if QL_MAPPINGS_PATH.exists():
+        data = json.loads(QL_MAPPINGS_PATH.read_text(encoding="utf-8"))
+    else:
+        data = {"mappings": []}
+
+    for entry in data["mappings"]:
+        if entry["original_ql"] == original_ql:
+            entry["patched_ql"] = patched_ql
+            break
+    else:
+        data["mappings"].append({
+            "original_ql": original_ql,
+            "patched_ql": patched_ql,
+        })
+
+    QL_MAPPINGS_PATH.write_text(json.dumps(data, indent=4, ensure_ascii=False), encoding="utf-8")
+
+
 def patch_ql(
     patched_ql_path: str,
-    new_content: str
+    new_content: str,
+    original_ql_path: Optional[str] = None,
 ) -> dict:
     """
-    将新内容写入指定的 QL 文件
-    
+    将新内容写入指定的 QL 文件，并自动维护映射表。
+
     Args:
-        patched_ql_path: 目标 QL 文件路径
+        patched_ql_path: 目标 QL 文件路径（建议位于 scripts/.CODEQL-AI/patched-ql/）
         new_content: 要写入的新内容
-    
+        original_ql_path: 被修补的原始 QL 文件的绝对路径（可选，提供后自动更新映射表）
+
     Returns:
         包含执行结果的字典
     """
     file_path = Path(patched_ql_path)
-    
+
     try:
-        # 确保父目录存在
         file_path.parent.mkdir(parents=True, exist_ok=True)
-        
-        # 写入新内容
         file_path.write_text(new_content, encoding='utf-8')
-        
+
+        if original_ql_path:
+            _update_ql_mappings(
+                str(Path(original_ql_path).resolve()),
+                str(file_path.resolve()),
+            )
+
         return {
             "success": True,
             "patched_ql_path": str(file_path),
+            "patched_ql_dir": str(PATCHED_QL_DIR),
+            "ql_mappings_path": str(QL_MAPPINGS_PATH),
             "message": f"QL 文件已成功写入: {file_path}"
         }
     except Exception as e:

--- a/src/libs/lib_sanitizer/readme.md
+++ b/src/libs/lib_sanitizer/readme.md
@@ -38,6 +38,45 @@
     *   **输入**: `patched_ql_path`  和 `new_content` (包含新 Sanitizer 定义的完整或片段 QL 代码)。
     *   **目的**: 将新的 Sanitizer 逻辑写入查询脚本，消除误报。
 
+### Patched QL 输出规范
+
+所有 patched QL 文件**必须**写入统一的输出目录，而非直接覆盖原始 QL 文件：
+
+*   **输出目录**: `<project_root>/scripts/.CODEQL-AI/patched-ql/`
+*   **文件命名**: 使用原始 QL 文件名，例如原始文件为 `CWE-190.ql`，则输出为 `scripts/.CODEQL-AI/patched-ql/CWE-190.ql`。
+*   **`patched_ql_path` 必须使用绝对路径**。
+
+### 维护 QL 映射表
+
+每次调用 `patch_ql` 后，你**必须**更新映射表 JSON 文件 `<project_root>/scripts/.CODEQL-AI/ql_mappings.json`。
+
+映射表格式：
+```json
+{
+    "mappings": [
+        {
+            "original_ql": "/absolute/path/to/original.ql",
+            "patched_ql": "/absolute/path/to/scripts/.CODEQL-AI/patched-ql/original.ql"
+        }
+    ]
+}
+```
+
+维护规则：
+1.  **路径必须使用绝对路径**。
+2.  **同一原始 QL 不重复添加**：如果 `original_ql` 已存在于 `mappings` 中，只需用新的 patched 内容覆盖 `patched_ql` 指向的文件，无需新增条目。
+3.  **首次处理某个原始 QL 时**，向 `mappings` 数组追加一条新记录。
+4.  如果文件不存在则创建，如果已存在则读取后追加/更新。
+
+此映射表可供 `scripts/swap_ql.py` 使用，实现批量替换和还原：
+```bash
+# 用 patched QL 替换原始文件（自动备份到 scripts/.CODEQL-AI/old-ql/）
+python3 scripts/swap_ql.py apply scripts/.CODEQL-AI/ql_mappings.json
+
+# 还原为原始文件
+python3 scripts/swap_ql.py restore scripts/.CODEQL-AI/ql_mappings.json
+```
+
 ## Step 5: 保存可复用经验
 如果 Step 4 中确认某个项目内部函数或模式具有 Sanitizer 效果，请使用工具 `save_experience_pattern` 将其保存为结构化经验，供后续 database 分析复用。
 *   **输入**: 一个 JSON 对象，至少包含：

--- a/src/mcptools/function_level_sanitizer.py
+++ b/src/mcptools/function_level_sanitizer.py
@@ -38,11 +38,17 @@ def read_function_implementation_tool(function_name: str, file_path: str) -> dic
 
 @mcp.tool(
     name="patch_ql",
-    description="将新内容写入指定的 QL 文件"
+    description=(
+        "将优化后的 QL 查询写入指定路径，并自动维护 original→patched 映射表。\n"
+        "参数说明：\n"
+        "- patched_ql_path (必填): patched QL 的输出绝对路径，必须位于 scripts/.CODEQL-AI/patched-ql/ 目录下\n"
+        "- new_content (必填): 完整的优化后 QL 文件内容\n"
+        "- original_ql_path (必填): 被修补的原始 QL 文件的绝对路径，用于自动更新 scripts/.CODEQL-AI/ql_mappings.json 映射表"
+    ),
 )
-def patch_ql_tool(patched_ql_path: str, new_content: str) -> dict:
-    """将新内容写入指定的 QL 文件"""
-    return patch_ql(patched_ql_path, new_content)
+def patch_ql_tool(patched_ql_path: str, new_content: str, original_ql_path: str = "") -> dict:
+    """将优化后的 QL 查询写入 patched-ql 目录，并更新映射表"""
+    return patch_ql(patched_ql_path, new_content, original_ql_path or None)
 
 if __name__ == "__main__":
     if len(sys.argv) > 1 and sys.argv[1] == "--stdio":


### PR DESCRIPTION
Summary

  - 新增 scripts/swap_ql.py：双向 QL 文件替换脚本，支持批量将 patched QL 应用到原始位置，也支持一键还原
  - patch_ql 工具新增 original_ql_path 参数，调用时自动维护 ql_mappings.json 映射表
  - 更新 lib_sanitizer prompt，规范 patched QL 的输出目录和映射表维护流程

  背景

  lib_sanitizer 的误报修复流程会对 SARIF 中的每个误报结果迭代处理，同一个原始 QL 文件可能被 patch 多次。之前 patched QL
  直接写入任意路径，没有统一管理，导致：
  1. 无法追踪哪些原始 QL 被修改过
  2. 无法批量替换/还原
  3. 多次 patch 后丢失最初的原始版本

  工作流

  1. 自动阶段（LLM 通过 MCP tool 完成）

  LLM 在 prompt 指导下调用 patch_ql 时：
  - patched QL 输出到 scripts/.CODEQL-AI/patched-ql/ 目录
  - 自动更新 scripts/.CODEQL-AI/ql_mappings.json 映射表
  - 同一原始 QL 多次 patch 只保留一条映射记录，patched 文件原地覆盖

  映射表格式：
  {
      "mappings": [
          {
              "original_ql": "/abs/path/to/CWE-190.ql",
              "patched_ql": "/abs/path/to/scripts/.CODEQL-AI/patched-ql/CWE-190.ql"
          }
      ]
  }

  2. 手动阶段（用户通过 swap_ql.py 完成）

  # 查看当前映射状态（哪些 QL 有备份、文件是否存在）
  python3 scripts/swap_ql.py status scripts/.CODEQL-AI/ql_mappings.json

  # 应用：备份原始 QL → scripts/.CODEQL-AI/old-ql/，用 patched 覆盖原始位置
  python3 scripts/swap_ql.py apply scripts/.CODEQL-AI/ql_mappings.json

  # 还原：将备份写回原始位置
  python3 scripts/swap_ql.py restore scripts/.CODEQL-AI/ql_mappings.json

  # 强制覆盖已有备份（慎用，会丢失最初的原始版本）
  python3 scripts/swap_ql.py apply --force scripts/.CODEQL-AI/ql_mappings.json

  典型场景

  1. 评估 patched QL 效果：apply → 运行 CodeQL 扫描 → 对比结果 → restore 还原
  2. 确认无误后正式替换：apply 后不再 restore
  3. 多轮迭代：LLM 多次 patch 同一 QL，每次覆盖 patched-ql/ 中的文件；用户随时 apply 测试最新版本，不满意则 restore

  目录结构

  scripts/
  ├── .CODEQL-AI/
  │   ├── ql_mappings.json      # 映射表（patch_ql 自动维护）
  │   ├── patched-ql/           # patched QL 输出目录
  │   │   └── CWE-190.ql
  │   └── old-ql/               # 原始 QL 备份（swap_ql.py apply 时生成）
  │       └── abs__path__to__CWE-190.ql
  └── swap_ql.py

  Test plan

  - [x] patch_ql 传入 original_ql_path 后正确生成 ql_mappings.json
  - [x] 重复 patch 同一原始 QL，映射表不重复添加
  - [x] swap_ql.py apply/restore/status 三种模式正常工作
  - [ ] 集成到完整的误报修复流程中端到端验证