### PR TITLE
fix: unify QL output paths to scripts/.CODEQL-AI/patched-ql/

### DIFF
--- a/src/libs/config.py
+++ b/src/libs/config.py
@@ -1,0 +1,15 @@
+"""Shared project-wide path constants."""
+
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+# CodeQL-AI managed directories (consistent with scripts/swap_ql.py)
+CODEQL_AI_DIR = PROJECT_ROOT / "scripts" / ".CODEQL-AI"
+PATCHED_QL_DIR = CODEQL_AI_DIR / "patched-ql"
+QL_MAPPINGS_PATH = CODEQL_AI_DIR / "ql_mappings.json"
+OLD_QL_DIR = CODEQL_AI_DIR / "old-ql"
+
+# Knowledge base
+DEFAULT_KNOWLEDGE_BASE = PROJECT_ROOT / "knowledge"
+DEFAULT_RULE_MAP = PROJECT_ROOT / "knowledge" / "rule_id_map.json"

--- a/src/libs/lib_fp_experience/lib_fp_extract.py
+++ b/src/libs/lib_fp_experience/lib_fp_extract.py
@@ -2,8 +2,8 @@ import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-PROJECT_ROOT = Path(__file__).resolve().parents[3]
-DEFAULT_RULE_MAP = PROJECT_ROOT / "knowledge" / "rule_id_map.json"
+from libs.config import DEFAULT_RULE_MAP
+
 DEFAULT_SOURCE_ROOT = "/data/benchmark/juliet/juliet-test-suite-c"
 
 

--- a/src/libs/lib_fp_experience/readme_fp_apply.md
+++ b/src/libs/lib_fp_experience/readme_fp_apply.md
@@ -72,7 +72,7 @@
 
 **输入**：用户确认要应用的经验 + 目标 QL 文件。
 
-**输出**：向用户展示的修改方案（diff 形式），确认后写入 `src/ql_queries/<原文件名>_fp_optimized.ql`。
+**输出**：向用户展示的修改方案（diff 形式），确认后写入 `scripts/.CODEQL-AI/patched-ql/<原文件名>.ql`。
 
 **使用工具**：`read_source_context`（如需查看源码上下文）、`patch_ql`
 
@@ -99,18 +99,20 @@
 
 **使用工具**：`patch_ql`
 
-*	**目录**：`src/ql_queries/`（如不存在会自动创建）。
-*	**命名规则**：`<原文件名>_fp_optimized.ql`
+*	**目录**：`scripts/.CODEQL-AI/patched-ql/`（如不存在会自动创建）。
+*	**命名规则**：使用原始 QL 文件名，例如 `CWE-190.ql`。
+*	**`patched_ql_path` 必须使用绝对路径**。
 *	**禁止覆盖原始 QL 文件**。
 *	同一 QL 被多条经验同时优化时，合并修改后输出一个文件。
+*	调用 `patch_ql` 时会自动维护 `scripts/.CODEQL-AI/ql_mappings.json` 映射表，供 `scripts/swap_ql.py` 批量替换和还原。
 
 ## Step 5: 后续验证建议
 
 **输出**：验证建议步骤。
 
 修改完成后，向用户建议：
-1.	使用 `src/ql_queries/` 下优化后的 QL 文件对项目代码运行 CodeQL 扫描。
-2.	对比使用原始 QL 和 `_fp_optimized.ql` 的结果，确认误报是否减少。
+1.	使用 `scripts/.CODEQL-AI/patched-ql/` 下优化后的 QL 文件对项目代码运行 CodeQL 扫描。
+2.	对比使用原始 QL 和 patched QL 的结果，确认误报是否减少。
 3.	如果优化有效，使用 `update_experience_validation` 提升该经验的置信度。
 4.	如果优化无效，记录失败原因。
 
@@ -120,7 +122,7 @@
 *	在调用工具前，用中文简要说明分析思路。
 *	匹配阶段必须使用 `match_experience_to_ql` 工具。
 *	**任何对 QL 文件的修改，必须先向用户展示修改方案（diff 形式），用户确认后才能写入。**
-*	**禁止修改原始 QL 文件。** 优化后的 QL 文件统一输出到 `src/ql_queries/` 目录，用 `_fp_optimized.ql` 后缀标识。
+*	**禁止修改原始 QL 文件。** 优化后的 QL 文件统一输出到 `scripts/.CODEQL-AI/patched-ql/` 目录，使用原始 QL 文件名。
 *	同一 QL 文件可能被多条经验同时匹配，注意合并修改，避免相互覆盖。
 
 ---

--- a/src/libs/lib_knowledge/lib_knowledge.py
+++ b/src/libs/lib_knowledge/lib_knowledge.py
@@ -6,9 +6,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
-
-PROJECT_ROOT = Path(__file__).resolve().parents[3]
-DEFAULT_KNOWLEDGE_BASE = PROJECT_ROOT / "knowledge"
+from libs.config import DEFAULT_KNOWLEDGE_BASE
 
 ACTIVE_STATUSES = {"candidate", "active_low_confidence", "active", "active_high_confidence"}
 CONFIDENCE_ORDER = {

--- a/src/libs/lib_ql_optimizer/lib_ql_optimizer.py
+++ b/src/libs/lib_ql_optimizer/lib_ql_optimizer.py
@@ -6,8 +6,7 @@
 import re
 from pathlib import Path
 
-PROJECT_ROOT = Path(__file__).resolve().parents[3]
-PATCHED_QL_DIR = PROJECT_ROOT / "scripts" / ".CODEQL-AI" / "patched-ql"
+from libs.config import PATCHED_QL_DIR
 
 
 def _read_text(file_path: str) -> str:

--- a/src/libs/lib_ql_optimizer/lib_ql_optimizer.py
+++ b/src/libs/lib_ql_optimizer/lib_ql_optimizer.py
@@ -6,9 +6,8 @@
 import re
 from pathlib import Path
 
-
-CONFIG_QL_OUTPUT_DIR = str(Path(__file__).parent) + "/optimized_codeql_queries/"
-CONFIG_QL_OUPUT_SUFFIX = "_optimized.ql"
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+PATCHED_QL_DIR = PROJECT_ROOT / "scripts" / ".CODEQL-AI" / "patched-ql"
 
 
 def _read_text(file_path: str) -> str:
@@ -16,13 +15,6 @@ def _read_text(file_path: str) -> str:
     if not path.exists():
         raise FileNotFoundError(f"文件不存在: {path}")
     return path.read_text(encoding="utf-8")
-
-
-def _write_text(target_path: str, content: str) -> str:
-    path = Path(target_path)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(content, encoding="utf-8")
-    return str(path)
 
 
 def inspect_ql_query(ql_path: str) -> dict:
@@ -76,10 +68,9 @@ def inspect_source_code(source_code_path: str) -> dict:
     }
 
 
-def write_ql_query(ql_name: str, content: str) -> dict:
-    """将优化后的 QL 查询内容写回文件。"""
-    try:
-        target_path = _write_text(CONFIG_QL_OUTPUT_DIR + ql_name.replace(".ql", CONFIG_QL_OUPUT_SUFFIX), content)
-        return {"success": True, "ql_path": target_path, "ql_name": ql_name,  "message": "QL 查询已成功写入文件。"}
-    except Exception as exc:
-        return {"success": False, "error": str(exc), "ql_path": ql_name}
+def write_ql_query(ql_name: str, content: str, original_ql_path: str = "") -> dict:
+    """将优化后的 QL 查询写入 scripts/.CODEQL-AI/patched-ql/，并自动维护映射表。"""
+    from libs.lib_sanitizer import patch_ql
+
+    target_path = str(PATCHED_QL_DIR / ql_name)
+    return patch_ql(target_path, content, original_ql_path or None)

--- a/src/libs/lib_ql_optimizer/prompt.md
+++ b/src/libs/lib_ql_optimizer/prompt.md
@@ -19,7 +19,7 @@
 
 # Output
 
-你的输出是 1. 优化后的QL查询文件的文件名（只有文件名而不是路径，example：template.ql）和 2. 优化后的查询内容（完整的ql文件的内容）。确保优化后的查询能够正确地识别目标代码，并且不再误报输入的源代码。
+你的输出是 1. 优化后的QL查询文件的文件名（只有文件名而不是路径，example：template.ql）和 2. 优化后的查询内容（完整的ql文件的内容）。优化后的 QL 文件将自动写入 `scripts/.CODEQL-AI/patched-ql/` 目录。如果已知原始 QL 文件的绝对路径，可传入 `original_ql_path` 参数以自动维护 `scripts/.CODEQL-AI/ql_mappings.json` 映射表。确保优化后的查询能够正确地识别目标代码，并且不再误报输入的源代码。
 
 # Notable Points
 

--- a/src/libs/lib_sanitizer/__init__.py
+++ b/src/libs/lib_sanitizer/__init__.py
@@ -1,3 +1,4 @@
-from .lib_sanitizer import patch_ql, read_function_implementation, run_taint_analysis, PATCHED_QL_DIR, QL_MAPPINGS_PATH
+from .lib_sanitizer import patch_ql, read_function_implementation, run_taint_analysis
+from libs.config import PATCHED_QL_DIR, QL_MAPPINGS_PATH
 
 __all__ = ["run_taint_analysis", "read_function_implementation", "patch_ql", "PATCHED_QL_DIR", "QL_MAPPINGS_PATH"]

--- a/src/libs/lib_sanitizer/lib_sanitizer.py
+++ b/src/libs/lib_sanitizer/lib_sanitizer.py
@@ -234,9 +234,7 @@ def read_function_implementation(function_name: str, file_path: str) -> dict:
     
     return {"success": True, "error": f"可能为lib库标准函数: {function_name}"}
 
-PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
-PATCHED_QL_DIR = PROJECT_ROOT / "scripts" / ".CODEQL-AI" / "patched-ql"
-QL_MAPPINGS_PATH = PROJECT_ROOT / "scripts" / ".CODEQL-AI" / "ql_mappings.json"
+from libs.config import PATCHED_QL_DIR, QL_MAPPINGS_PATH
 
 
 def _update_ql_mappings(original_ql: str, patched_ql: str) -> None:

--- a/src/mcptools/ql_optimizer.py
+++ b/src/mcptools/ql_optimizer.py
@@ -31,11 +31,11 @@ def inspect_source_code_tool(source_code_path: str) -> dict:
 
 @mcp.tool(
     name="write_ql_query",
-    description="将优化后的 QL 查询写入指定文件，输入为ql文件的文件名（仅文件名，不含路径，example：query.ql）和新的ql查询内容（完整的ql查询内容）"
+    description="将优化后的 QL 查询写入 scripts/.CODEQL-AI/patched-ql/ 目录，输入为ql文件的文件名（仅文件名，不含路径，example：query.ql）、新的ql查询内容（完整的ql查询内容），以及可选的原始 QL 文件绝对路径（用于自动更新 ql_mappings.json 映射表）"
 )
-def write_ql_query_tool(ql_name: str, ql_content: str) -> dict:
-    """将优化后的 QL 查询写入指定文件"""
-    return write_ql_query(ql_name, ql_content)
+def write_ql_query_tool(ql_name: str, ql_content: str, original_ql_path: str = "") -> dict:
+    """将优化后的 QL 查询写入 patched-ql 目录，并更新映射表"""
+    return write_ql_query(ql_name, ql_content, original_ql_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What Changed
  
  - lib_ql_optimizer/lib_ql_optimizer.py: write_ql_query() 输出路径从 src/libs/lib_ql_optimizer/optimized_codeql_queries/ 改为 scripts/.CODEQL-AI/patched-ql/，委托 patch_ql() 自动维护 ql_mappings.json 映射表。删除了不再使用的
  _write_text 辅助函数和旧常量路径。
  - lib_fp_experience/readme_fp_apply.md: prompt 中引导 agent 的输出目录从 src/ql_queries/<name>_fp_optimized.ql 改为 scripts/.CODEQL-AI/patched-ql/<name>.ql，新增映射表维护说明。

## Why

  项目中存在两套不一致的 QL 输出约定：
  1. lib_sanitizer 的 patch_ql() 正确输出到 scripts/.CODEQL-AI/patched-ql/ 并维护 ql_mappings.json
  2. lib_ql_optimizer 输出到自己的 optimized_codeql_queries/ 子目录，不维护映射表 
  3. readme_fp_apply.md prompt 引导 agent 写入不存在的 src/ql_queries/ 目录

  导致 scripts/swap_ql.py 无法发现和批量 apply/restore 这些 patched 文件。

## Scope and Impact

  - 受影响文件（2 个）: src/libs/lib_ql_optimizer/lib_ql_optimizer.py, src/libs/lib_fp_experience/readme_fp_apply.md
  - 用户影响: 所有优化后的 QL 文件统一到 scripts/.CODEQL-AI/patched-ql/，可通过 swap_ql.py 批量替换和还原
  - 兼容性: write_ql_query() 新增的 original_ql_path 为可选参数，现有调用无需修改
close #25 

## Validation

  - [x] python3 -c "from libs.lib_ql_optimizer import ..." 导入成功
  - [x] PATCHED_QL_DIR 正确解析为 /home/zhenyu/repos/CodeQL-AI/scripts/.CODEQL-AI/patched-ql
  - [x] lib_sanitizer 现有 __init__.py 的导出不受影响

## Checklist

  - [x] 已审阅变更代码，无无关修改
  - [x] 向后兼容，无破坏性变更
  - [x] 无新增外部依赖